### PR TITLE
Radialdepth

### DIFF
--- a/LE_roseengine/static/js/roseengine.js
+++ b/LE_roseengine/static/js/roseengine.js
@@ -45,6 +45,7 @@ $(function() {
         self.geo_stages = ko.observable(2);
         self.geo_points = ko.observable(6000);
         self.saved_geos = ko.observableArray([]);
+        self.radial_depth = ko.observable(0.0);
 
         //Recording
         self.recording  = ko.observable(false);
@@ -715,6 +716,7 @@ $(function() {
                 bref: self.bref(),
                 laser_base: self.laser_base(),
                 laser_feed: self.laser_feed(),
+                radial_depth: self.radial_depth(),
                
 
             };

--- a/LE_roseengine/templates/roseengine_tab.jinja2
+++ b/LE_roseengine/templates/roseengine_tab.jinja2
@@ -151,6 +151,10 @@
                         <button id="geo_save" class="btn" data-bind="click: function() {save_geo()}">Save Geo</button>
                     </div>
                     <div>
+                        <label for="radial_depth" title="Adjust depth of cut based on radius. Positive values will cut deeper at the center, negative values will cut deeper at the max radius" >Radial depth (mm):</label>
+                        <input class="span4" id="radial_depth" type="number" step="any" data-bind="value: radial_depth">
+                    </div>
+                    <div>
                         <label>Saved Geometrics:</label>
                             <select id="saved_geo_select" data-bind="">
                         </select>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "LE-RoseEngine"
-version = "0.1.13"
+version = "0.1.14"
 
 description = "Rose Engine emulator for the LatheEngraver"
 authors = [


### PR DESCRIPTION
Adds two main features:

* geometric chuck now has a radial depth setting. This is the value  (in mm) that is the difference between the max radius and the center point. Positives values will cut deeper in the center. Negative values will cut deeper at the max radius.
* Rosette data from COrnLathe can be read directly. The text file extension needs to the .clr to be able to upload to the rosette folder.