### PR TITLE
Rework rosettes

### DIFF
--- a/LE_roseengine/__init__.py
+++ b/LE_roseengine/__init__.py
@@ -142,6 +142,7 @@ class RoseenginePlugin(octoprint.plugin.SettingsPlugin,
         self.use_m3 = bool(self._settings.get(["use_m3"]))
         self.laser_start = bool(self._settings.get(["laser_start"]))
         self.laser_stop = bool(self._settings.get(["laser_stop"]))
+        self.exp = bool(self._settings.get(["exp"]))
 
         storage = self._file_manager._storage("local")
         
@@ -179,7 +180,8 @@ class RoseenginePlugin(octoprint.plugin.SettingsPlugin,
             r_radius=50,
             r_stage=10,
             r_phase=False,
-            r_phase_v=45
+            r_phase_v=45,
+            exp=False
             )
     
     def get_template_configs(self):
@@ -1041,6 +1043,14 @@ class RoseenginePlugin(octoprint.plugin.SettingsPlugin,
         self.working_z = working_z
         self.working_angles = working_angles
         self.working_mod = mod_array
+
+        if self.ecc_offset and self.pump_main and self.rock_main:
+            self.working_x = np.zeros_like(working_z)
+            msg = dict(
+                        title="Warning!",
+                        text="Eccentric offset of rocking rosette with a pumping rosette is not compatible. Ignoring pumping.",
+                        type="warning")
+            self.send_le_error(msg)
 
         self.start_coords["x"] = self.current_x
         self.start_coords["z"] = self.current_z

--- a/LE_roseengine/__init__.py
+++ b/LE_roseengine/__init__.py
@@ -745,8 +745,6 @@ class RoseenginePlugin(octoprint.plugin.SettingsPlugin,
 
         try:
             bf_target = self.bf_target
-            #TODO: new implementation currently ignores direction!
-            dir = "" if self.forward else "-"
             degrees_sec = (self.rpm * 360) / 60
             degrees_chunk = self.chunk * self.a_inc
             loop_start = None
@@ -764,7 +762,13 @@ class RoseenginePlugin(octoprint.plugin.SettingsPlugin,
             if len(phasecmds):
                 cmdlist.extend(phasecmds)
             track = {"x": self.start_coords["x"], "z": self.start_coords["z"], "a": self.start_coords["a"]}
-            #track_z = self.start_coords["z"]
+            
+            if not self.forward:
+                self.working_angles = self.working_angles*-1
+                #self.working_x = np.flip(self.working_x)
+                #self.working_z = np.flip(self.working_z)
+                #self.working_mod = np.flip(self.working_mod)
+
             while self.running:
                 self.buffer = 0
                 degrees_sec = (self.rpm * 360) / 60
@@ -825,7 +829,6 @@ class RoseenginePlugin(octoprint.plugin.SettingsPlugin,
                             #self._logger.info(f"Zdiff is {zdiff} delta_ov is {delta_ov}")
                         if self.laser_mode and self.laser:
                             #calculate the chunk distance
-                            #THIS IS NO LONGER CORRECT!!!
                             arc = track["z"] * math.radians(self.a_inc)
                             chunk_distance = chunk_distance + math.sqrt(arc**2 + x**2 + z**2)
 

--- a/LE_roseengine/__init__.py
+++ b/LE_roseengine/__init__.py
@@ -89,8 +89,8 @@ class RoseenginePlugin(octoprint.plugin.SettingsPlugin,
 
         #geometric chuck
         self.geo = geometric.GeometricChuck()
-        self.geo_radii = None
-        self.geo_angles = None
+        self.geo_radii = []
+        self.geo_angles = []
         self.geo_depth = None
         self.geo_points = 6000
         self.geo_thresh = 500

--- a/LE_roseengine/profiles.py
+++ b/LE_roseengine/profiles.py
@@ -1,0 +1,96 @@
+import os 
+import time
+import math
+import numpy as np
+from scipy.interpolate import CubicSpline
+from scipy.interpolate import RectBivariateSpline
+from scipy.integrate import quad
+from scipy.optimize import root_scalar
+
+#this is being adapted from Profiler plugin
+
+def createsplines(_plugin, filepath):
+    folder = _plugin._settings.getBaseFolder("uploads")
+    filename = f"{folder}/{filepath}"
+    ind_v = []
+    dep_v = []
+    datapoints = []
+    segments = []
+    current_segment = []
+    with open(filename,"r") as file:
+        for line in file:
+            stripped_line = line.strip()
+            if stripped_line == ";X":
+                axis = 'X'
+            if stripped_line == ";Z":
+                axis = 'Z'
+            if stripped_line == "NEXTSEGMENT":
+                segments.append(current_segment)
+                current_segment = []
+                continue
+            if not stripped_line.startswith(";"):
+                # Split the line by comma and convert to floats
+                try:
+                    parts = [float(x) for x in stripped_line.split(",")]
+                    # Pad to 3 elements
+                    while len(parts) < 3:
+                        parts.append(0.0)
+                    current_segment.append(parts)
+                except ValueError:
+                    pass
+    if not len(segments):
+        segments.append(current_segment)
+    
+    arr = np.array(segments)
+    #sort, must be increasing
+    if axis == 'Z':
+        for seg in segments:
+            seg.sort(key=lambda x: x[1])
+        ind_v = [x[1] for x in segments[0]]
+        dep_v = [x[0] for x in segments[0]]
+        ind_vals = arr[0, :, 1]
+        A_vals = arr[:, 0, 2]
+        baseline_dep = arr[0, :, 0]
+        dep_raw = arr[:, :, 0]
+        dep_grid = dep_raw - baseline_dep
+
+    if _plugin.axis == 'X':
+        for seg in segments:
+            seg.sort(key=lambda x: x[0])
+        ind_v = [x[0] for x in segments[0]]
+        dep_v = [x[1] for x in segments[0]]
+        ind_vals = arr[0, :, 0]
+        A_vals = arr[:, 0, 2]
+        baseline_dep = arr[0, :, 1]
+        dep_raw = arr[:, :, 1]
+        dep_grid = dep_raw - baseline_dep
+
+    _plugin.spline = CubicSpline(ind_v, dep_v)
+
+
+    #do any ind_val offsets here?
+    current_max = ind_v[-1]
+    current_min = ind_v[0]
+    
+    sort_idx = np.argsort(ind_vals)
+    ind_vals = ind_vals[sort_idx]
+    dep_grid = dep_grid[:, sort_idx]
+
+    _plugin._logger.info(ind_vals)
+    _plugin._logger.info(dep_grid)
+    A_radians = np.deg2rad(np.mod(A_vals, 360.0))
+    if A_radians[0] == 0 and A_vals[-1] == 360:
+        A_radians = np.append(A_radians, 2 * np.pi)
+        Z_grid = np.vstack([Z_grid, Z_grid[0]])
+    _plugin.a_spline = RectBivariateSpline(A_radians, ind_vals, dep_grid, kx=3, ky=3, s=0)
+
+def ovality_mod(_plugin, x, a_deg):
+
+    zdiff = _plugin.spline(x)
+    a_wrapped = np.deg2rad(np.mod(a_deg, 360.0))
+    adiff = _plugin.a_spline.ev(a_wrapped, x)
+    #_plugin._logger.info(f"Z diff from X: {zdiff} Z diff from rot {adiff}")
+    #does it make sense to have both of these or can I just use adiff?
+    #after contemplation, this won't be useful with recorded gcode, so it makes sense to just use adiffink
+    return adiff
+

--- a/LE_roseengine/static/js/roseengine.js
+++ b/LE_roseengine/static/js/roseengine.js
@@ -32,6 +32,7 @@ $(function() {
         self.pump_invert = ko.observable(0);
 
         self.phase_offset = ko.observable(0);
+        self.ecc_offset = ko.observable(0.0);
         self.s_amp = ko.observable(1.0);
         self.peak = ko.observable(1);
         self.pshift = ko.observable(0.0);
@@ -500,7 +501,8 @@ $(function() {
                     max: data.maxrad,
                     min: data.minrad,
                 };
-                this.createPolarPlot(data.type, rosette_info);
+                //this.createPolarPlot(data.type, rosette_info);
+                Plotly.newPlot('rockarea', data.graph.data, data.graph.layout,{displayModeBar: false});
                 if (self.special) {
                     self.special_warning("on","rock");
                 }
@@ -523,7 +525,7 @@ $(function() {
                     max: data.maxrad,
                     min: data.minrad,
                 };
-                this.createPolarPlot(data.type, rosette_info);
+                Plotly.newPlot('pumparea', data.graph.data, data.graph.layout,{displayModeBar: false});
                 if (self.special) {
                     self.special_warning("on","pump");
                 }
@@ -699,7 +701,8 @@ $(function() {
         self.load_rosette = function(filePath, type) {
             var data = {
                 filepath: filePath,
-                type: type
+                type: type,
+                ecc_offset: self.ecc_offset(),
             };
 
             OctoPrint.simpleApiCommand("roseengine", "load_rosette", data)

--- a/LE_roseengine/static/js/roseengine.js
+++ b/LE_roseengine/static/js/roseengine.js
@@ -258,6 +258,10 @@ $(function() {
             self.geo_stages = self.settings.geo_stages();
             self.geo_points = self.settings.geo_points();
             self.relative_return = self.settings.relative_return();
+            self.r_radius = self.settings.r_radius();
+            self.r_stage = self.settings.r_stage();
+            self.r_phase = self.settings.r_phase();
+            self.r_phase_v = self.settings.r_phase_v();
             var numStages = parseInt(self.geo_stages, 10);
             var stagesArr = [];
             for (var i = 0; i < numStages; i++) {
@@ -591,11 +595,18 @@ $(function() {
         
         self.create_geo = function(randomize) {
             var stages_data = self.stages().map(function(stage, idx) {
+                var spq = (self.r_stage*2)+1;
                 if (randomize) {
-                    var radius = Math.floor(Math.random() * 50) + 1;
-                    var p = Math.floor(Math.random() * 21) - 10;
-                    var q = Math.floor(Math.random() * 21) - 10;
-                    var phase = 0;
+                    var radius = Math.floor(Math.random() * self.r_radius) + 1;
+                    var p = Math.floor(Math.random() * spq) - self.r_stage;
+                    var q = Math.floor(Math.random() * spq) - self.r_stage;
+
+                    if (self.r_phase) {
+                        var phase = Math.floor(Math.random() * self.r_phase_v) + 1;
+                    }
+                    else {
+                        var phase = 0;
+                    }
 
                     // Update the knockout observables so UI reflects the random values
                     stage.radius(radius);
@@ -620,7 +631,7 @@ $(function() {
                     };
                 }
             });
-            console.log(stages_data);
+            //console.log(stages_data);
             OctoPrint.simpleApiCommand("roseengine", "geometric", { stages: stages_data, samples: self.geo_points })
                 .done(function(response) {
                     console.log("Geometric data sent");

--- a/LE_roseengine/static/js/roseengine.js
+++ b/LE_roseengine/static/js/roseengine.js
@@ -61,6 +61,9 @@ $(function() {
         self.laser_feed = ko.observable(200);
         self.laser_mode = ko.observable(0);
 
+        //experimental
+        self.exp = ko.observable(false);
+
         tab = document.getElementById("tab_plugin_roseengine_link");
         tab.innerHTML = tab.innerHTML.replaceAll("Roseengine Plugin", "Rose Engine");
 
@@ -262,6 +265,10 @@ $(function() {
             self.r_stage = self.settings.r_stage();
             self.r_phase = self.settings.r_phase();
             self.r_phase_v = self.settings.r_phase_v();
+
+            self.exp = self.settings.exp();
+            //console.log(self.exp_feature)
+
             var numStages = parseInt(self.geo_stages, 10);
             var stagesArr = [];
             for (var i = 0; i < numStages; i++) {
@@ -301,6 +308,10 @@ $(function() {
 
             if(!self.is_printing() || self.running()) {
                 self.available(true);
+            }
+
+            if (self.exp_feature() === "true") {
+                self.exp(true);
             }
 
             //console.log(self.available());

--- a/LE_roseengine/templates/roseengine_settings.jinja2
+++ b/LE_roseengine/templates/roseengine_settings.jinja2
@@ -20,16 +20,16 @@
             <i class="icon icon-info-sign" title="" data-toggle="tooltip"></i>
         </label>
         <label>
-            <input type="checkbox" data-bind="checked: settings.plugins.roseengine.auto_reset"> Auto-reset on stop
+            <input type="checkbox" data-bind="checked: settings.plugins.roseengine.auto_reset">  Auto-reset on stop
             <i class="icon icon-info-sign" title="" data-toggle="tooltip"></i>
         </label>
         <label>
-            <input type="checkbox" data-bind="checked: settings.plugins.roseengine.relative_return">Return to relative start position during recording
+            <input type="checkbox" data-bind="checked: settings.plugins.roseengine.relative_return">  Return to relative start position during recording
             <i class="icon icon-info-sign" title="" data-toggle="tooltip"></i>
         </label>
         <h3>Laser options</h3>
         <label>
-            <input type="checkbox" data-bind="checked: settings.plugins.roseengine.power_correct">Perform laser power correction based on calculated linear movements
+            <input type="checkbox" data-bind="checked: settings.plugins.roseengine.power_correct">  Perform laser power correction based on calculated linear movements
             <i class="icon icon-info-sign" title="" data-toggle="tooltip"></i>
         </label>
         <label>
@@ -37,11 +37,11 @@
             <i class="icon icon-info-sign" title="" data-toggle="tooltip"></i>
         </label>
         <label>
-            <input type="checkbox" data-bind="checked: settings.plugins.roseengine.laser_start">Start laser with run
+            <input type="checkbox" data-bind="checked: settings.plugins.roseengine.laser_start">  Start laser with run
             <i class="icon icon-info-sign" title="" data-toggle="tooltip"></i>
         </label>
         <label>
-            <input type="checkbox" data-bind="checked: settings.plugins.roseengine.laser_stop">Stop run after single pass
+            <input type="checkbox" data-bind="checked: settings.plugins.roseengine.laser_stop">  Stop run after single pass
             <i class="icon icon-info-sign" title="" data-toggle="tooltip"></i>
         </label>
         <label>
@@ -70,6 +70,30 @@
         </label>
         <label>
             <input type="number" step="1" min="50" max="20000" class="input-mini" data-bind="numeric, value: settings.plugins.roseengine.geo_interp"> Interpolation resampling points
+            <i class="icon icon-info-sign" title="" data-toggle="tooltip"></i>
+        </label>
+
+
+
+
+        <label>
+            <input type="number" step="1" class="input-mini" data-bind="numeric, value: settings.plugins.roseengine.r_radius"> Random radius max value
+            <i class="icon icon-info-sign" title="" data-toggle="tooltip"></i>
+        </label>
+
+        <label>
+            <input type="number" step="1" class="input-mini" data-bind="numeric, value: settings.plugins.roseengine.r_stage"> Random p/q max value
+            <i class="icon icon-info-sign" title="" data-toggle="tooltip"></i>
+        </label>
+
+
+        <label>
+            <input type="checkbox" data-bind="checked: settings.plugins.roseengine.r_phase">  Randomize phase?
+            <i class="icon icon-info-sign" title="" data-toggle="tooltip"></i>
+        </label>
+
+        <label>
+            <input type="number" step="1" class="input-mini" data-bind="numeric, value: settings.plugins.roseengine.r_phase_v"> Random phase max value
             <i class="icon icon-info-sign" title="" data-toggle="tooltip"></i>
         </label>
     </div>

--- a/LE_roseengine/templates/roseengine_settings.jinja2
+++ b/LE_roseengine/templates/roseengine_settings.jinja2
@@ -1,58 +1,63 @@
 <form class="form-horizontal">
     <div class="control-group">
+        <h3>Experimental/Development</h3>
+        <label>
+            <input type="checkbox" data-bind="checked: settings.plugins.roseengine.exp">  Show any experimental features
+            <i class="icon icon-info-sign" title="Reload page after changing this option" data-toggle="tooltip"></i>
+        </label>
         <h3>Control Options</h3>
         <label>
             <input type="number" step="any" min="0.1" max="60.0" class="input-mini" data-bind="value: settings.plugins.roseengine.a_inc"> Rotation angle increment
-            <i class="icon icon-info-sign" title="" data-toggle="tooltip"></i>
+            <i class="icon icon-info-sign" title="Default angular increments" data-toggle="tooltip"></i>
         </label>
         <br>
         <label>
             <input type="number" step="1" min="1" max="60" class="input-mini" data-bind="value: settings.plugins.roseengine.chunk"> Command chunk size
-            <i class="icon icon-info-sign" title="" data-toggle="tooltip"></i>
+            <i class="icon icon-info-sign" title="Number of commands sent at each time." data-toggle="tooltip"></i>
         </label>
         <br>
         <label>
             <input type="number" step="1" min="0" max="95" class="input-mini" data-bind="value: settings.plugins.roseengine.bf_threshold"> Buffer threshold
-            <i class="icon icon-info-sign" title="" data-toggle="tooltip"></i>
+            <i class="icon icon-info-sign" title="Delay sending commands if buffer threshold is below  this value." data-toggle="tooltip"></i>
         </label>
         <label>
             <input type="number" step="1" min="0" max="200" class="input-mini" data-bind="numeric, value: settings.plugins.roseengine.ms_threshold"> Millisecond threshold
-            <i class="icon icon-info-sign" title="" data-toggle="tooltip"></i>
+            <i class="icon icon-info-sign" title="If buffer is above threshold and if calculated time for next chunk is less than this value, next command chunk is sent." data-toggle="tooltip"></i>
         </label>
         <label>
             <input type="checkbox" data-bind="checked: settings.plugins.roseengine.auto_reset">  Auto-reset on stop
-            <i class="icon icon-info-sign" title="" data-toggle="tooltip"></i>
+            <i class="icon icon-info-sign" title="Return to start position each time a run is stopped." data-toggle="tooltip"></i>
         </label>
         <label>
             <input type="checkbox" data-bind="checked: settings.plugins.roseengine.relative_return">  Return to relative start position during recording
-            <i class="icon icon-info-sign" title="" data-toggle="tooltip"></i>
+            <i class="icon icon-info-sign" title="Uses markers to return to relative (not absolute) position during recording." data-toggle="tooltip"></i>
         </label>
         <h3>Laser options</h3>
         <label>
             <input type="checkbox" data-bind="checked: settings.plugins.roseengine.power_correct">  Perform laser power correction based on calculated linear movements
-            <i class="icon icon-info-sign" title="" data-toggle="tooltip"></i>
+            <i class="icon icon-info-sign" title="Decreases laser power as the radius decreases. This REQUIRES zeroing Z-axis at actual Z=0." data-toggle="tooltip"></i>
         </label>
         <label>
             <input type="checkbox" data-bind="checked: settings.plugins.roseengine.use_m3">Use M3, rather than M4
-            <i class="icon icon-info-sign" title="" data-toggle="tooltip"></i>
+            <i class="icon icon-info-sign" title="M4 automatically adjusts laser power based on acceleration. This can be used instead of power correction." data-toggle="tooltip"></i>
         </label>
         <label>
             <input type="checkbox" data-bind="checked: settings.plugins.roseengine.laser_start">  Start laser with run
-            <i class="icon icon-info-sign" title="" data-toggle="tooltip"></i>
+            <i class="icon icon-info-sign" title="Starts the laser as soon as the run begins" data-toggle="tooltip"></i>
         </label>
         <label>
             <input type="checkbox" data-bind="checked: settings.plugins.roseengine.laser_stop">  Stop run after single pass
-            <i class="icon icon-info-sign" title="" data-toggle="tooltip"></i>
+            <i class="icon icon-info-sign" title="Stops the laser after one complete cycle." data-toggle="tooltip"></i>
         </label>
         <label>
             <input type="number" step="1" min="1" max="10" class="input-mini" data-bind="numeric, value: settings.plugins.roseengine.max_correct">
             Maximum power correction scale factor
-            <i class="icon icon-info-sign" title="" data-toggle="tooltip"></i>
+            <i class="icon icon-info-sign" title="When power scaling is used, this is the maximum scale factor from the set power." data-toggle="tooltip"></i>
         </label>
         <label>
             <input type="number" step="any" class="input-mini" data-bind="numeric, value: settings.plugins.roseengine.min_correct">
             Minimum power correction scale factor
-            <i class="icon icon-info-sign" title="" data-toggle="tooltip"></i>
+            <i class="icon icon-info-sign" title="when power scaling is used, this is the minimum scale factor from the set power." data-toggle="tooltip"></i>
         </label>
         <br>
         <h3>Geometric Chuck options</h3>
@@ -66,11 +71,11 @@
         </label>
         <label>
             <input type="number" step="1" min="10" max="10000" class="input-mini" data-bind="numeric, value: settings.plugins.roseengine.geo_thresh"> Interpolation point threshold
-            <i class="icon icon-info-sign" title="" data-toggle="tooltip"></i>
+            <i class="icon icon-info-sign" title="If the number of sampling points is below this value, the data will be re-interpolated. This allows straight lines." data-toggle="tooltip"></i>
         </label>
         <label>
             <input type="number" step="1" min="50" max="20000" class="input-mini" data-bind="numeric, value: settings.plugins.roseengine.geo_interp"> Interpolation resampling points
-            <i class="icon icon-info-sign" title="" data-toggle="tooltip"></i>
+            <i class="icon icon-info-sign" title="The number of sampling points  during re-interpolation." data-toggle="tooltip"></i>
         </label>
 
 

--- a/LE_roseengine/templates/roseengine_tab.jinja2
+++ b/LE_roseengine/templates/roseengine_tab.jinja2
@@ -17,6 +17,12 @@
                     <label title="Amplitude scale factor for rocking" for="r_amp">Rock amplitude:</label>
                     <input id="r_amp" type="number" value="0.5" max="5.0" step="any" data-bind="value: r_amp">            
                 </div>
+
+                <div>
+                    <label title="Radial eccentric offset, in mm" for="r_amp">Eccentric offset:</label>
+                    <input id="ecc_offset" type="number" min="0.0" value="0" step="any" data-bind="value: ecc_offset">
+                </div>
+
                 <div class="parametric">
                     <details>
                         <summary>Periodic Wave Functions</summary>

--- a/LE_roseengine/templates/roseengine_tab.jinja2
+++ b/LE_roseengine/templates/roseengine_tab.jinja2
@@ -74,10 +74,16 @@
                         <input id="pump_invert" type="checkbox" data-bind="checked: pump_invert">
                     </label>
                 </div>
+                <div>
+                    <label>Available X scans:</label>
+                        <select id="scan_pump_select" data-bind="">
+                    </select>
+                </div>
                 <div style="margin-top: auto; display: flex; justify-content: center;">
                     <button id="clear_rock" class="btn" data-bind="click: function() {clear_rosette('pump')}"> Clear</button>
                 </div>
                 <!-- Add more pump-specific controls here if needed -->
+                
             </div>
         </div>
         
@@ -247,7 +253,7 @@
                 </tbody>
             </table>    
             </div>
-            <div id=laser_numbers data-bind="visible: laser_mode">
+            <div id=laser_numbers data-bind="visible: laser_mode()">
                 <label title="The base laser power, 0 to 1000" for="laser_power">Laser Power:</label>
                 <input id="laser_power" type="number" max="1000" value="1" step="1" data-bind="value: laser_base">
 

--- a/LE_roseengine/templates/roseengine_tab.jinja2
+++ b/LE_roseengine/templates/roseengine_tab.jinja2
@@ -18,7 +18,7 @@
                     <input id="r_amp" type="number" value="0.5" max="5.0" step="any" data-bind="value: r_amp">            
                 </div>
 
-                <div>
+                <div data-bind="visible: exp">
                     <label title="Radial eccentric offset, in mm" for="r_amp">Eccentric offset:</label>
                     <input id="ecc_offset" type="number" min="0.0" value="0" step="any" data-bind="value: ecc_offset">
                 </div>
@@ -80,7 +80,7 @@
                         <input id="pump_invert" type="checkbox" data-bind="checked: pump_invert">
                     </label>
                 </div>
-                <div>
+                <div data-bind="visible: exp">
                     <label>Available X scans:</label>
                         <select id="scan_pump_select" data-bind="">
                     </select>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "LE-RoseEngine"
-version = "0.1.14"
+version = "0.1.15"
 
 description = "Rose Engine emulator for the LatheEngraver"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "LE-RoseEngine"
-version = "0.1.15"
+version = "0.1.16"
 
 description = "Rose Engine emulator for the LatheEngraver"
 authors = [


### PR DESCRIPTION
Major changes in this version:
* Rework how rosettes work
* All plotly happens on the python side and is sent to front ends as json, as there were weird issues with plotly js library side
* Added control over Random settings for geometric chuck
* Added a setting to turn experimental features on/off
* Experimental features added:
 ** Eccentric offset - essential the same as an eccentric chuck. Only works with Rocking.
 ** Can use X-axis scans in conjunction with pumping to compensate for out-of-round or other features. Must have a set A and X zero point that corresponds with the scan!