### PR TITLE
Use Centroid, Rename geometrics

### DIFF
--- a/LE_roseengine/__init__.py
+++ b/LE_roseengine/__init__.py
@@ -481,9 +481,33 @@ class RoseenginePlugin(octoprint.plugin.SettingsPlugin,
 
     def resample_path_to_polar(self, path, center=None, radial_offset=0.0):
         if not center:
-            xmin, xmax, ymin, ymax = path.bbox()
-            cx = (xmin + xmax) / 2
-            cy = (ymin + ymax) / 2
+            N_CENTROID = 2000
+            t_vals = np.linspace(0.0, 1.0, N_CENTROID, endpoint=False)
+            pts = np.array([[path.point(t).real, path.point(t).imag] for t in t_vals])
+            x_pts = pts[:, 0]
+            y_pts = pts[:, 1]
+
+            bb_cx = (x_pts.min() + x_pts.max()) / 2.0
+            bb_cy = (y_pts.min() + y_pts.max()) / 2.0
+            angles_sort = np.arctan2(y_pts - bb_cy, x_pts - bb_cx)
+            sort_idx = np.argsort(angles_sort)
+            x_pts = x_pts[sort_idx]
+            y_pts = y_pts[sort_idx]
+
+            x_next = np.roll(x_pts, -1)
+            y_next = np.roll(y_pts, -1)
+            cross = x_pts * y_next - x_next * y_pts
+            A = 0.5 * np.sum(cross)
+
+            if abs(A) < 1e-10:
+                #stick with bounding box
+                cx = bb_cx
+                cy = bb_cy
+                self._logger.debug(f"Below threshold, cx, cy: {cx}, {cy}")
+            else:
+                cx = np.sum((x_pts + x_next) * cross) / (6.0 * A)
+                cy = np.sum((y_pts + y_next) * cross) / (6.0 * A)
+                self._logger.debug(f"Calculated centroid cx, cy: {cx}, {cy}")
         else:
             cx = center[0]
             cy = center[1]

--- a/LE_roseengine/__init__.py
+++ b/LE_roseengine/__init__.py
@@ -1534,6 +1534,7 @@ class RoseenginePlugin(octoprint.plugin.SettingsPlugin,
             laser=[],
             save_geo=[],
             curve=[],
+            rename_geo=["index","name"],
         )
     
     def on_api_command(self, command, data):
@@ -1648,6 +1649,26 @@ class RoseenginePlugin(octoprint.plugin.SettingsPlugin,
                 returndata = dict(type="curve", graph=json_figure)
                 self._plugin_manager.send_plugin_message('roseengine', returndata)
 
+        if command == "rename_geo":
+            import flask
+            index = data.get("index")
+            name = data.get("name")
+            folder = self._settings.getBaseFolder("uploads")
+            json_path = os.path.join(folder, "rosette", "saved_geos.json")
+            try:
+                with open(json_path, "r") as f:
+                    geos = json.load(f)
+                if not isinstance(geos, list) or index >= len(geos):
+                    return flask.make_response("Invalid index", 400)
+                geos[index]["timestamp"] = name
+                with open(json_path, "w") as f:
+                    json.dump(geos, f, indent=2)
+                self._logger.info(f"Renamed geo entry {index} to '{name}'")
+            except Exception as e:
+                self._logger.error(f"Failed to rename geo entry: {e}", exc_info=True)
+                return flask.make_response("Error", 500)
+            return flask.make_response("OK", 200)
+        
         if command == "save_geo":
             """
             Append current geometric chuck definition to uploads/rosette/saved_geos.json

--- a/LE_roseengine/static/js/roseengine.js
+++ b/LE_roseengine/static/js/roseengine.js
@@ -179,7 +179,7 @@ $(function() {
                                 data.forEach(function(entry, i) {
                                     var label = entry.timestamp ? entry.timestamp : ("entry " + i);
                                     //console.log(label);
-                                    if (entry.type) label = label + " (" + entry.type + ")";
+                                    if (entry.type) label = label;
                                     sel.append($("<option>").text(label).attr("value", i));
                                 });
                             }
@@ -354,6 +354,26 @@ $(function() {
                     self.loadSavedGeo(val);
                 }
             });
+
+        $("#saved_geo_select").on("contextmenu", function(e) {
+            e.preventDefault();
+            var val = $(this).val();
+            if (val === "" || val === null) return;
+            var entry = self.saved_geos()[parseInt(val, 10)];
+            if (!entry) return;
+            var currentName = entry.timestamp || ("entry " + val);
+            var newName = prompt("Enter new name for this entry:", currentName);
+            if (newName === null || newName.trim() === "") return;
+            OctoPrint.simpleApiCommand("roseengine", "rename_geo", { index: parseInt(val, 10), name: newName.trim() })
+                .done(function() {
+                    console.log("Geo entry renamed");
+                    self.fetchSavedGeos();
+                })
+                .fail(function() {
+                    console.error("Failed to rename geo entry");
+                });
+            self.fetchSavedGeos();
+        });
 
         $("#scan_pump_select").on("change", function () {
             var filePath = $("#scan_pump_select option:selected").attr("path");

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "LE-RoseEngine"
-version = "0.2.3"
+version = "0.2.4"
 
 
 description = "Rose Engine emulator for the LatheEngraver"


### PR DESCRIPTION
This transitions to using centroid calculation for center of rosettes.
Saved geometric chucks can be renamed. Design must be loaded, then right click to open rename dialogue.